### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Again, it is possible to use arithmetic and boolean operators
         if Name == "Ekin" && LastName == "Koc"
             p Hey! I know you..
 
-There is a special syntax for conditional attributes. Only block attribues can have conditions;
+There is a special syntax for conditional attributes. Only block attributes can have conditions;
 
     div
         .hasfriends ? Friends > 0
@@ -268,7 +268,7 @@ var DefaultOptions = Options{true, false}
 ```go
 func Compile(input string, options Options) (*template.Template, error)
 ```
-Parses and compiles the supplied amber template string. Returns correspondind Go
+Parses and compiles the supplied amber template string. Returns corresponding Go
 Template (html/templates) instance. Necessary runtime functions will be injected
 and the template will be ready to be executed.
 
@@ -277,7 +277,7 @@ and the template will be ready to be executed.
 ```go
 func CompileFile(filename string, options Options) (*template.Template, error)
 ```
-Parses and compiles the contents of supplied filename. Returns correspondind Go
+Parses and compiles the contents of supplied filename. Returns corresponding Go
 Template (html/templates) instance. Necessary runtime functions will be injected
 and the template will be ready to be executed.
 
@@ -345,7 +345,7 @@ Compile method to obtain a template instance directly.
 ```go
 func (c *Compiler) Parse(input string) (err error)
 ```
-Parse given raw amber tempalte string.
+Parse given raw amber template string.
 
 #### func (*Compiler) ParseFile
 

--- a/compiler.go
+++ b/compiler.go
@@ -71,9 +71,9 @@ type Options struct {
 	// Setting if pretty printing is enabled.
 	// Pretty printing ensures that the output html is properly indented and in human readable form.
 	// If disabled, produced HTML is compact. This might be more suitable in production environments.
-	// Defaukt: true
+	// Default: true
 	PrettyPrint bool
-	// Setting if line number emiting is enabled
+	// Setting if line number emitting is enabled
 	// In this form, Amber emits line number comments in the output template. It is usable in debugging environments.
 	// Default: false
 	LineNumbers bool
@@ -81,7 +81,7 @@ type Options struct {
 
 var DefaultOptions = Options{true, false}
 
-// Parses and compiles the supplied amber template string. Returns correspondind Go Template (html/templates) instance.
+// Parses and compiles the supplied amber template string. Returns corresponding Go Template (html/templates) instance.
 // Necessary runtime functions will be injected and the template will be ready to be executed.
 func Compile(input string, options Options) (*template.Template, error) {
 	comp := New()
@@ -95,7 +95,7 @@ func Compile(input string, options Options) (*template.Template, error) {
 	return comp.Compile()
 }
 
-// Parses and compiles the contents of supplied filename. Returns correspondind Go Template (html/templates) instance.
+// Parses and compiles the contents of supplied filename. Returns corresponding Go Template (html/templates) instance.
 // Necessary runtime functions will be injected and the template will be ready to be executed.
 func CompileFile(filename string, options Options) (*template.Template, error) {
 	comp := New()
@@ -109,7 +109,7 @@ func CompileFile(filename string, options Options) (*template.Template, error) {
 	return comp.Compile()
 }
 
-// Parse given raw amber tempalte string.
+// Parse given raw amber template string.
 func (c *Compiler) Parse(input string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -127,7 +127,7 @@ func (c *Compiler) Parse(input string) (err error) {
 	return
 }
 
-// Parse the amber tempalte file in given path
+// Parse the amber template file in given path
 func (c *Compiler) ParseFile(filename string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/doc.go
+++ b/doc.go
@@ -158,7 +158,7 @@ Again, it is possible to use arithmetic and boolean operators
         if Name == "Ekin" && LastName == "Koc"
             p Hey! I know you..
 
-There is a special syntax for conditional attributes. Only block attribues can have conditions;
+There is a special syntax for conditional attributes. Only block attributes can have conditions;
 
     div
         .hasfriends ? Friends > 0
@@ -212,7 +212,7 @@ gets compiled to
 
 Inheritance
 
-A tamplate can inherit other templates. In order to inherit another template, an `extends` keyword should be used.
+A template can inherit other templates. In order to inherit another template, an `extends` keyword should be used.
 Parent template can define several named blocks and child template can modify the blocks.
 
     master.amber
@@ -236,7 +236,7 @@ Parent template can define several named blocks and child template can modify th
 
         block append meta
             // This will be added after the description meta tag. It is also possible
-            // to prepend someting to an existing block
+            // to prepend something to an existing block
             meta[name="keywords"][content="foo bar"]
 
         block content


### PR DESCRIPTION
This fixes some misspellings in the documentation
