### PR TITLE
Fix raw attribute double quotation

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -350,7 +350,7 @@ func (c *Compiler) visitTag(tag *parser.Tag) {
 		} else if item.Value == "" {
 			attr.value = ""
 		} else {
-			attr.value = `{{"` + item.Value + `"}}`
+			attr.value = item.Value
 		}
 
 		if len(item.Condition) != 0 {


### PR DESCRIPTION
Sometimes attributes would be double quoted. For example [type="button"] would work as intended and emit type="button" but [onclick="console.log('test')"] would emit onclick=""console.log('test')"".
