### PR TITLE
Add mixin functionality

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -55,6 +55,7 @@ type Compiler struct {
 	newline      bool
 	buffer       *bytes.Buffer
 	tempvarIndex int
+	mixins       map[string]*parser.Mixin
 }
 
 // Create and initialize a new Compiler
@@ -64,6 +65,7 @@ func New() *Compiler {
 	compiler.tempvarIndex = 0
 	compiler.PrettyPrint = true
 	compiler.Options = DefaultOptions
+	compiler.mixins = make(map[string]*parser.Mixin)
 
 	return compiler
 }
@@ -306,6 +308,10 @@ func (c *Compiler) visit(node parser.Node) {
 		c.visitEach(node.(*parser.Each))
 	case *parser.Assignment:
 		c.visitAssignment(node.(*parser.Assignment))
+	case *parser.Mixin:
+		c.visitMixin(node.(*parser.Mixin))
+	case *parser.MixinCall:
+		c.visitMixinCall(node.(*parser.MixinCall))
 	}
 }
 
@@ -681,4 +687,16 @@ func (c *Compiler) visitExpression(outerexpr ast.Expr) string {
 
 	exec(outerexpr)
 	return pop()
+}
+
+func (c *Compiler) visitMixin(mixin *parser.Mixin) {
+	c.mixins[mixin.Name] = mixin
+}
+
+func (c *Compiler) visitMixinCall(mixinCall *parser.MixinCall) {
+	mixin := c.mixins[mixinCall.Name]
+	for i, arg := range mixin.Args {
+		c.write(fmt.Sprintf(`{{%s := %s}}`, arg, c.visitRawInterpolation(mixinCall.Args[i])))
+	}
+	c.visitBlock(mixin.Block)
 }

--- a/parser/nodes.go
+++ b/parser/nodes.go
@@ -1,5 +1,7 @@
 package parser
 
+import "regexp"
+
 var selfClosingTags = [...]string{
 	"meta",
 	"img",
@@ -221,4 +223,50 @@ func newAssignment(x, expression string) *Assignment {
 	assgn.X = x
 	assgn.Expression = expression
 	return assgn
+}
+
+type Mixin struct {
+	SourcePosition
+	Block *Block
+	Name  string
+	Args  []string
+}
+
+func newMixin(name, args string) *Mixin {
+	mixin := new(Mixin)
+	mixin.Name = name
+
+	delExp := regexp.MustCompile(`,\s`)
+	mixin.Args = delExp.Split(args, -1)
+
+	return mixin
+}
+
+type MixinCall struct {
+	SourcePosition
+	Name string
+	Args []string
+}
+
+func newMixinCall(name, args string) *MixinCall {
+	mixinCall := new(MixinCall)
+	mixinCall.Name = name
+
+	const t = "%s"
+	quoteExp := regexp.MustCompile(`"(.*?)"`)
+	delExp := regexp.MustCompile(`,\s`)
+
+	quotes := quoteExp.FindAllString(args, -1)
+	replaced := quoteExp.ReplaceAllString(args, t)
+	mixinCall.Args = delExp.Split(replaced, -1)
+
+	qi := 0
+	for i, arg := range mixinCall.Args {
+		if arg == t {
+			mixinCall.Args[i] = quotes[qi]
+			qi++
+		}
+	}
+
+	return mixinCall
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -158,6 +158,10 @@ func (p *Parser) parse() Node {
 		return p.parseExtends()
 	case tokIndent:
 		return p.parseBlock(nil)
+	case tokMixin:
+		return p.parseMixin()
+	case tokMixinCall:
+		return p.parseMixinCall()
 	}
 
 	panic(fmt.Sprintf("Unexpected token: %d", p.currenttoken.Kind))
@@ -400,4 +404,23 @@ readmore:
 	}
 
 	return tag
+}
+
+func (p *Parser) parseMixin() *Mixin {
+	tok := p.expect(tokMixin)
+	mixin := newMixin(tok.Value, tok.Data["Args"])
+	mixin.SourcePosition = p.pos()
+
+	if p.currenttoken.Kind == tokIndent {
+		mixin.Block = p.parseBlock(mixin)
+	}
+
+	return mixin
+}
+
+func (p *Parser) parseMixinCall() *MixinCall {
+	tok := p.expect(tokMixinCall)
+	mixinCall := newMixinCall(tok.Value, tok.Data["Args"])
+	mixinCall.SourcePosition = p.pos()
+	return mixinCall
 }


### PR DESCRIPTION
I've added Jade-style mixin functionality:

```
mixin input($id, $label, $type)
    label[for=$id] #{$label}
    input[id=$id][type=$type]
!!! 5
html
    body
        form
            +input("name", "Enter your name", "text")
            +input("occupation", "Enter your occupation", "text")
```

compiles to:

``` html
<!DOCTYPE html>
<html>
    <body>
        <form>{{$id := "name"}}{{$label := "Enter your name"}}{{$type := "text"}}
            <label for="{{$id}}">{{$label}}</label>
            <input id="{{$id}}" type="{{$type}}" />{{$id := "occupation"}}{{$label := "Enter your occupation"}}{{$type := "text"}}
            <label for="{{$id}}">{{$label}}</label>
            <input id="{{$id}}" type="{{$type}}" />
        </form>
    </body>
</html>
```

which executes to:

``` html
<!DOCTYPE html>
<html>
    <body>
        <form>
            <label for="name">Enter your name</label>
            <input id="name" type="text" />
            <label for="occupation">Enter your occupation</label>
            <input id="occupation" type="text" />
        </form>
    </body>
</html>
```

Template data, variables, expressions, etc., can also be passed to the mixin:

```
+input(SomeId, $someLabel, "te" + "xt")
```

Let me know what you think or if anything is buggy. Thanks for the good work with Amber.
