### PR TITLE
Allow to access functions from FuncMap

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -668,8 +668,13 @@ func (c *Compiler) visitExpression(outerexpr ast.Expr) string {
 				stack.PushFront(ce.Fun.(*ast.Ident).Name)
 				c.write(`{{` + name + ` := ` + pop())
 			} else {
-				exec(ce.Fun)
-				c.write(`{{` + name + ` := call ` + pop())
+				switch ce.Fun.(type) {
+				case *ast.Ident:
+					stack.PushFront(ce.Fun.(*ast.Ident).Name)
+				default:
+					exec(ce.Fun)
+				}
+				c.write(`{{` + name + ` := ` + pop())
 			}
 
 			for i := 0; i < len(ce.Args); i++ {


### PR DESCRIPTION
Seems, that calling only works for built-in functions, because

```
#{foo($bar)}
```

transforms into `{{call .foo $bar}}`, but should be without `.` character.
It can cause #25 issue.
More elegant solutions are welcome :)
