### PR TITLE
Parsing data without converting to string

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -29,6 +29,14 @@ func StringParser(input string) (*Parser, error) {
 	return newParser(bytes.NewReader([]byte(input))), nil
 }
 
+func ByteParser(input []byte) (*Parser, error) {
+	return newParser(bytes.NewReader(input)), nil
+}
+
+func (p *Parser) SetFilename(filename string) {
+	p.filename = filename
+}
+
 func FileParser(filename string) (*Parser, error) {
 	data, err := ioutil.ReadFile(filename)
 


### PR DESCRIPTION
Making it possible to read the contents of a file and providing both the contents and the filename to Amber, as an alternative to Amber reading the file (or a string, without a filename).

This avoids a conversion from `[]byte` to `string` in [algernon](https://github.com/xyproto/algernon) and also makes it possible to manipulate the bytes before sending them to Amber, while keeping the functionality that is available when the Amber parser has been given a filename.

Please accept, reject or ask me to make changes to the pull request.

Best regards,
   Alexander F Rødseth