### PR TITLE
Allow to call FuncMap functions and struct's method with arguments

### DIFF
--- a/amber_test.go
+++ b/amber_test.go
@@ -174,6 +174,38 @@ func Test_FuncCall(t *testing.T) {
 	}
 }
 
+func Test_FuncMapFunctionCall(t *testing.T) {
+	FuncMap["upper"] = strings.ToUpper
+
+	res, err := run(`#{ upper("test") }`, nil)
+
+	if err != nil {
+		t.Fatal(err.Error())
+	} else {
+		expect(res, `TEST`, t)
+	}
+}
+
+type DummyStruct struct {
+	X string
+}
+
+func (d DummyStruct) MethodWithArg(s string) string {
+	return d.X + " " + s
+}
+
+func Test_StructMethodCall(t *testing.T) {
+	d := DummyStruct{X: "Hello"}
+
+	res, err := run(`#{ $.MethodWithArg("world") }`, d)
+
+	if err != nil {
+		t.Fatal(err.Error())
+	} else {
+		expect(res, `Hello world`, t)
+	}
+}
+
 func Failing_Test_CompileDir(t *testing.T) {
 	tmpl, err := CompileDir("samples/", DefaultDirOptions, DefaultOptions)
 

--- a/compiler.go
+++ b/compiler.go
@@ -727,11 +727,26 @@ func (c *Compiler) visitExpression(outerexpr ast.Expr) string {
 						break
 					}
 				}
+				for fname, _ := range FuncMap {
+					if fname == ident.Name {
+						builtin = true
+						break
+					}
+				}
 			}
 
 			if builtin {
 				stack.PushFront(ce.Fun.(*ast.Ident).Name)
 				c.write(`{{` + name + ` := ` + pop())
+			} else if se, ok := ce.Fun.(*ast.SelectorExpr); ok {
+				exec(se.X)
+				x := pop()
+
+				if x == "." {
+					x = ""
+				}
+				stack.PushFront(se.Sel.Name)
+				c.write(`{{` + name + ` := ` + x + `.` + pop())
 			} else {
 				exec(ce.Fun)
 				c.write(`{{` + name + ` := call ` + pop())


### PR DESCRIPTION
This fixes the same issue described at #27. It's simply different from #27 that this keeps all idents behavior which isn't defined as `FuncMap` function as is.

This also adds calling struct's method functionality. Please see `Test_StructMethodCall` test case in `amber_test.go` for more details.