### PR TITLE
Added a slice of attribute names to preserve the order of iteration

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -5,7 +5,6 @@ import (
 	"container/list"
 	"errors"
 	"fmt"
-	"github.com/eknkc/amber/parser"
 	"go/ast"
 	gp "go/parser"
 	gt "go/token"
@@ -17,6 +16,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/eknkc/amber/parser"
 )
 
 var builtinFunctions = [...]string{
@@ -473,6 +474,7 @@ func (c *Compiler) visitTag(tag *parser.Tag) {
 	}
 
 	attribs := make(map[string]*attrib)
+	attrNames := make([]string, 0, 0)
 
 	for _, item := range tag.Attributes {
 		attr := new(attrib)
@@ -506,6 +508,9 @@ func (c *Compiler) visitTag(tag *parser.Tag) {
 
 			prevclass.value = prevclass.value + attr.value
 		} else {
+			if _, ok := attribs[item.Name]; !ok {
+				attrNames = append(attrNames, item.Name)
+			}
 			attribs[item.Name] = attr
 		}
 	}
@@ -513,7 +518,8 @@ func (c *Compiler) visitTag(tag *parser.Tag) {
 	c.indent(0, true)
 	c.write("<" + tag.Name)
 
-	for name, value := range attribs {
+	for _, name := range attrNames {
+		value := attribs[name]
 		if len(value.condition) > 0 {
 			c.write(`{{if ` + value.condition + `}}`)
 		}


### PR DESCRIPTION
Ok, a slice of attributes won't work because there might be attributes with the same name.
Yet, keeping another slice of map keys obviously fixes the problem. If you prefer - you might add `sort.Strings(attrNames)` to make the order of keys defined by the alphabet.