### PR TITLE
fix endless loop when inherit blocks

### DIFF
--- a/amber_test.go
+++ b/amber_test.go
@@ -232,6 +232,22 @@ func Test_Multiple_File_Inheritance(t *testing.T) {
 	expect(strings.TrimSpace(res.String()), "<p>This is C</p>", t)
 }
 
+func Test_Recursion_In_Blocks(t *testing.T) {
+	tmpl, err := CompileDir("samples/", DefaultDirOptions, DefaultOptions)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	top, ok := tmpl["recursion.top"]
+	if !ok || top == nil {
+		t.Fatal("template not found.")
+	}
+
+	var res bytes.Buffer
+	top.Execute(&res, nil)
+	expect(strings.TrimSpace(res.String()), "content", t)
+}
+
 func Failing_Test_CompileDir(t *testing.T) {
 	tmpl, err := CompileDir("samples/", DefaultDirOptions, DefaultOptions)
 

--- a/amberc/cli.go
+++ b/amberc/cli.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	amber "github.com/eknkc/amber"
 	"os"
+
+	amber "github.com/eknkc/amber"
 )
 
 var prettyPrint bool

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -449,6 +449,8 @@ func findTopmostParentWithNamedBlock(p *Parser, name string) *Parser {
 		}
 		if top.parent.namedBlocks[name] != nil {
 			top = top.parent
+		} else {
+			return top
 		}
 	}
 }

--- a/samples/recursion.extends.amber
+++ b/samples/recursion.extends.amber
@@ -1,0 +1,4 @@
+extends recursion.parent.amber
+
+block main
+    block inner

--- a/samples/recursion.parent.amber
+++ b/samples/recursion.parent.amber
@@ -1,0 +1,1 @@
+block main

--- a/samples/recursion.top.amber
+++ b/samples/recursion.top.amber
@@ -1,0 +1,4 @@
+extends recursion.extends.amber
+
+block inner
+    | content


### PR DESCRIPTION
Without that change `go test` will stuck in endless loop.