### PR TITLE
Add support for @ signs in attributes

### DIFF
--- a/amber_test.go
+++ b/amber_test.go
@@ -110,14 +110,14 @@ func Test_Id(t *testing.T) {
 }
 
 func Test_Attribute(t *testing.T) {
-	res, err := run(`div[name="Test"][foo="bar"].testclass
+	res, err := run(`div[name="Test"][@foo="bar"].testclass
 						p
 							[style="text-align: center; color: maroon"]`, nil)
 
 	if err != nil {
 		t.Fatal(err.Error())
 	} else {
-		expect(res, `<div class="testclass" foo="bar" name="Test"><p style="text-align: center; color: maroon"></p></div>`, t)
+		expect(res, `<div @foo="bar" class="testclass" name="Test"><p style="text-align: center; color: maroon"></p></div>`, t)
 	}
 }
 

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -358,7 +358,7 @@ func (s *scanner) scanClassName() *token {
 	return nil
 }
 
-var rgxAttribute = regexp.MustCompile(`^\[([\w\-:]+)\s*(?:=\s*(\"([^\"\\]*)\"|([^\]]+)))?\](?:\s*\?\s*(.*)$)?`)
+var rgxAttribute = regexp.MustCompile(`^\[([\w\-:@]+)\s*(?:=\s*(\"([^\"\\]*)\"|([^\]]+)))?\](?:\s*\?\s*(.*)$)?`)
 
 func (s *scanner) scanAttribute() *token {
 	if sm := rgxAttribute.FindStringSubmatch(s.buffer); len(sm) != 0 {


### PR DESCRIPTION
This pull requests adds support for @ signs in attribute names. This can be helpful when you are using the [Vue.js](https://vuejs.org/) JavaScript framework, where [@ signs can be used in attributes as a shorthand](https://vuejs.org/v2/guide/syntax.html#v-on-Shorthand).