### PR TITLE
Support for virtual filesystems

### DIFF
--- a/amber_test.go
+++ b/amber_test.go
@@ -363,7 +363,7 @@ func expect(cur, expected string, t *testing.T) {
 }
 
 func run(tpl string, data interface{}) (string, error) {
-	t, err := Compile(tpl, Options{false, false})
+	t, err := Compile(tpl, Options{false, false, nil})
 	if err != nil {
 		return "", err
 	}

--- a/compiler.go
+++ b/compiler.go
@@ -172,7 +172,13 @@ func MustCompileFile(filename string, options Options) *template.Template {
 // in all subdirectories. The key then is the path e.g: "layouts/layout"
 func CompileDir(dirname string, dopt DirOptions, opt Options) (map[string]*template.Template, error) {
 	dir, err := os.Open(dirname)
-	if err != nil {
+	if err != nil && opt.VirtualFilesystem != nil {
+		vdir, err := opt.VirtualFilesystem.Open(dirname)
+		if err != nil {
+			return nil, err
+		}
+		dir = vdir.(*os.File)
+	} else if err != nil {
 		return nil, err
 	}
 	defer dir.Close()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"path/filepath"
 	"strings"
 )
@@ -12,6 +13,7 @@ import (
 type Parser struct {
 	scanner      *scanner
 	filename     string
+	fs           http.FileSystem
 	currenttoken *token
 	namedBlocks  map[string]*NamedBlock
 	parent       *Parser
@@ -37,6 +39,10 @@ func (p *Parser) SetFilename(filename string) {
 	p.filename = filename
 }
 
+func (p *Parser) SetVirtualFilesystem(fs http.FileSystem) {
+	p.fs = fs
+}
+
 func FileParser(filename string) (*Parser, error) {
 	data, err := ioutil.ReadFile(filename)
 
@@ -46,6 +52,23 @@ func FileParser(filename string) (*Parser, error) {
 
 	parser := newParser(bytes.NewReader(data))
 	parser.filename = filename
+	return parser, nil
+}
+
+func VirtualFileParser(filename string, fs http.FileSystem) (*Parser, error) {
+	file, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := newParser(bytes.NewReader(data))
+	parser.filename = filename
+	parser.fs = fs
 	return parser, nil
 }
 
@@ -139,6 +162,9 @@ func (p *Parser) parseRelativeFile(filename string) *Parser {
 	}
 
 	parser, err := FileParser(filename)
+	if err != nil && p.fs != nil {
+		parser, err = VirtualFileParser(filename, p.fs)
+	}
 	if err != nil {
 		panic("Unable to read " + filename + ", Error: " + string(err.Error()))
 	}


### PR DESCRIPTION
I needed to add support for virtual filesystems (ex. implementing net/http.FileSystem interface) for a project I am working on which then compiles to a single standalone binary without any external resources so I am opening this PR to get suggestions what to improve and eventually merge it into master.