### PR TITLE
Add support for periods in attributes

### DIFF
--- a/amber_test.go
+++ b/amber_test.go
@@ -155,14 +155,14 @@ func Test_Id(t *testing.T) {
 }
 
 func Test_Attribute(t *testing.T) {
-	res, err := run(`div[name="Test"][@foo="bar"].testclass
+	res, err := run(`div[name="Test"][@foo.bar="baz"].testclass
 						p
 							[style="text-align: center; color: maroon"]`, nil)
 
 	if err != nil {
 		t.Fatal(err.Error())
 	} else {
-		expect(res, `<div @foo="bar" class="testclass" name="Test"><p style="text-align: center; color: maroon"></p></div>`, t)
+		expect(res, `<div @foo.bar="baz" class="testclass" name="Test"><p style="text-align: center; color: maroon"></p></div>`, t)
 	}
 }
 

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -358,7 +358,7 @@ func (s *scanner) scanClassName() *token {
 	return nil
 }
 
-var rgxAttribute = regexp.MustCompile(`^\[([\w\-:@]+)\s*(?:=\s*(\"([^\"\\]*)\"|([^\]]+)))?\](?:\s*\?\s*(.*)$)?`)
+var rgxAttribute = regexp.MustCompile(`^\[([\w\-:@\.]+)\s*(?:=\s*(\"([^\"\\]*)\"|([^\]]+)))?\](?:\s*\?\s*(.*)$)?`)
 
 func (s *scanner) scanAttribute() *token {
 	if sm := rgxAttribute.FindStringSubmatch(s.buffer); len(sm) != 0 {


### PR DESCRIPTION
Another pull request to permit a character in attribute names. Periods can be used in attribute names with the Vue.js framework.